### PR TITLE
update copyright year

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,22 @@
+#
+# Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # EditorConfig helps developers define and maintain consistent
 # coding styles between different editors and IDEs
 # http://editorconfig.org

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
-  ~
-  ~ See the NOTICE file(s) distributed with this work for additional
-  ~ information regarding copyright ownership.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ You may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<!--
+
+    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Acknowledgment.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Acknowledgment.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package org.eclipse.microprofile.reactive.messaging;
 
 import java.lang.annotation.Retention;

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Incoming.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Incoming.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging;
 
 import java.util.concurrent.CompletableFuture;

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/MessagingProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/MessagingProvider.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging;
 
 /**

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Outgoing.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Outgoing.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging;
 
 import java.lang.annotation.ElementType;

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/package-info.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 /**
  * The MicroProfile Reactive Messaging API.
  * <p>

--- a/approach.asciidoc
+++ b/approach.asciidoc
@@ -1,11 +1,11 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 = MicroProfile approach to reactive
 
 This document outlines the approach that MicroProfile will use to adopting the reactive paradigm for programming and architecting microservices.

--- a/mp_checkstyle_rules.xml
+++ b/mp_checkstyle_rules.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--*******************************************************************************
-* Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
-*
-* See the NOTICE file(s) distributed with this work for additional
-* information regarding copyright ownership.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* You may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************-->
+<!--
+
+    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
     "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <description>Eclipse MicroProfile Reactive Messaging :: Parent POM</description>
 
     <url>http://microprofile.io</url>
+    <inceptionYear>2018</inceptionYear>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -228,6 +229,31 @@
                     <logViolationsToConsole>true</logViolationsToConsole>
                     <configLocation>${project.basedir}/mp_checkstyle_rules.xml</configLocation>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <aggregate>true</aggregate>
+                    <header>src/license/license.txt</header>
+                    <properties>
+                        <year>2019</year>
+                        <owner>Eclipse MicroProfile</owner>
+                    </properties>
+                    <mapping>
+                        <asciidoc>DOUBLESLASH_STYLE</asciidoc>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+
+    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!--
     Licensed under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at

--- a/site.yaml
+++ b/site.yaml
@@ -1,21 +1,22 @@
-#######################################################################
-## Copyright (c) 2018 Contributors to the Eclipse Foundation
-##
-## See the NOTICE file(s) distributed with this work for additional
-## information regarding copyright ownership.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-#######################################################################
+#
+# Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 %YAML 1.2
 ---
 documentation:

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
-  ~
-  ~ See the NOTICE file(s) distributed with this work for additional
-  ~ information regarding copyright ownership.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ You may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<!--
+
+    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -1,8 +1,11 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0

--- a/spec/src/main/asciidoc/license-alv2.asciidoc
+++ b/spec/src/main/asciidoc/license-alv2.asciidoc
@@ -1,8 +1,11 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0

--- a/spec/src/main/asciidoc/microprofile-reactive-messaging-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-reactive-messaging-spec.asciidoc
@@ -1,8 +1,11 @@
 //
-// Copyright (c) 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0

--- a/src/license/license.txt
+++ b/src/license/license.txt
@@ -1,0 +1,17 @@
+Copyright (c) ${project.inceptionYear}-${year} Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (c) 2018 Contributors to the Eclipse Foundation
-  ~
-  ~ See the NOTICE file(s) distributed with this work for additional
-  ~ information regarding copyright ownership.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ You may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<!--
+
+    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/CompletionStageIncomingMethodVerification.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/CompletionStageIncomingMethodVerification.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ReactiveMessagingTck.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ReactiveMessagingTck.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck;
 
 import org.testng.annotations.Factory;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/TckMessagingManager.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/TckMessagingManager.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck;
 
 import org.eclipse.microprofile.reactive.messaging.tck.container.MockedReceiver;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TckArchiveAppender.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TckArchiveAppender.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.client;
 
 import org.eclipse.microprofile.reactive.messaging.tck.container.TckArquillianRemoteExtension;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TckArquillianExtension.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TckArquillianExtension.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.client;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TckDeployListener.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TckDeployListener.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.client;
 
 import org.eclipse.microprofile.reactive.messaging.tck.container.Topics;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TopicDeploymentScenario.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/TopicDeploymentScenario.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.client;
 
 import java.util.Collections;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/event/DeployTopics.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/event/DeployTopics.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.client.event;
 
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/event/TopicEvent.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/event/TopicEvent.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.client.event;
 
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/event/UnDeployTopics.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/client/event/UnDeployTopics.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.client.event;
 
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/ContainerPuppet.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/ContainerPuppet.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.eclipse.microprofile.reactive.messaging.Message;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockPayload.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockPayload.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import java.util.Objects;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockedReceiver.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockedReceiver.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.eclipse.microprofile.reactive.messaging.Message;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockedSender.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/MockedSender.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.eclipse.microprofile.reactive.messaging.Message;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/QuietRuntimeException.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/QuietRuntimeException.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 /**

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/ReceiveTimeoutException.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/ReceiveTimeoutException.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 /**

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/SimpleMessage.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/SimpleMessage.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.eclipse.microprofile.reactive.messaging.Message;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckArquillianRemoteExtension.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckArquillianRemoteExtension.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckContainerListener.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckContainerListener.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckDeploymentUtils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckDeploymentUtils.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.eclipse.microprofile.reactive.messaging.tck.TckMessagingManager;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckMessagingPuppet.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TckMessagingPuppet.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import org.eclipse.microprofile.reactive.messaging.Message;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TestEnvironment.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/TestEnvironment.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import java.time.Duration;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/Topics.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/Topics.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import java.lang.annotation.ElementType;

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/WaitAssert.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/container/WaitAssert.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,8 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package org.eclipse.microprofile.reactive.messaging.tck.container;
 
 import java.time.Duration;


### PR DESCRIPTION
This PR does 2 things:

1. Use the license maven plugin (this one: http://code.mycila.com/license-maven-plugin/) to generate license header automatically
2. Update the license header to 2019

The plugin is configured to generate the header on all file even asciidoctor file (which is not possible with the codehaus plugin).