### PR TITLE
Extend TCK with SubscriberBuilder

### DIFF
--- a/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantBeans.java
+++ b/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantBeans.java
@@ -24,8 +24,8 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Publisher;
 
 import javax.enterprise.context.Dependent;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Dependent
@@ -33,8 +33,8 @@ public class DependantBeans {
 
     private static final AtomicInteger COUNTER = new AtomicInteger();
     private final int id;
-    private List<Integer> list = new ArrayList<>();
-    private static final List<Integer> STATIC_LIST = new ArrayList<>();
+    private List<Integer> list = new CopyOnWriteArrayList<>();
+    private static final List<Integer> STATIC_LIST = new CopyOnWriteArrayList<>();
 
     public DependantBeans() {
         id = COUNTER.getAndIncrement();

--- a/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/VerifierForPublisherBean.java
+++ b/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/VerifierForPublisherBean.java
@@ -140,8 +140,8 @@ public class VerifierForPublisherBean {
         int limit = 10;
         assertThat(counters.get("generator-payload")).hasValue(limit);
         assertThat(counters.get("generator-message")).hasValue(limit);
-        assertThat(counters.get("generator-payload-async")).hasValue(limit + 1);
-        assertThat(counters.get("generator-message-async")).hasValue(limit + 1);
+        assertThat(counters.get("generator-payload-async")).hasValueBetween(limit, limit + 1);
+        assertThat(counters.get("generator-message-async")).hasValueBetween(limit, limit + 1);
     }
 
 }

--- a/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberBean.java
+++ b/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberBean.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
- *
+ * <p>
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * You may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.eclipse.microprofile.reactive.streams.operators.SubscriberBuilder;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 
@@ -42,141 +43,165 @@ import static org.eclipse.microprofile.reactive.messaging.tck.TckBase.EXECUTOR;
 @ApplicationScoped
 public class SubscriberBean {
 
-  private Map<String, List<String>> collector = new ConcurrentHashMap<>();
+    private Map<String, List<String>> collector = new ConcurrentHashMap<>();
 
-  private static final List<String> EXPECTED = Arrays.asList(
-    "1", "1",
-    "2", "2",
-    "3", "3",
-    "4", "4",
-    "5", "5",
-    "6", "6",
-    "7", "7",
-    "8", "8",
-    "9", "9",
-    "10", "10"
-  );
+    private static final List<String> EXPECTED = Arrays.asList(
+        "1", "1",
+        "2", "2",
+        "3", "3",
+        "4", "4",
+        "5", "5",
+        "6", "6",
+        "7", "7",
+        "8", "8",
+        "9", "9",
+        "10", "10"
+    );
 
-  private static Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+    private static Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
 
-  private static void increment(String counter) {
-    counters.computeIfAbsent(counter, x -> new AtomicInteger(0)).incrementAndGet();
-  }
+    private static void increment(String counter) {
+        counters.computeIfAbsent(counter, x -> new AtomicInteger(0)).incrementAndGet();
+    }
 
-  @Outgoing("subscriber-message")
-  public Publisher<Message<String>> sourceForSubscriberMessage() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Outgoing("subscriber-message")
+    public Publisher<Message<String>> sourceForSubscriberMessage() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Incoming("subscriber-message")
-  public Subscriber<Message<String>> subscriberOfMessages() {
-    increment("subscriber-message");
-    return ReactiveStreams.<Message<String>>builder().forEach(m -> add("subscriber-message", m.getPayload())).build();
-  }
+    @Incoming("subscriber-message")
+    public Subscriber<Message<String>> subscriberOfMessages() {
+        increment("subscriber-message");
+        return ReactiveStreams.<Message<String>>builder().forEach(m -> add("subscriber-message", m.getPayload()))
+            .build();
+    }
 
-  @Outgoing("subscriber-payload")
-  public Publisher<Message<String>> sourceForSubscribePayload() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Outgoing("subscriber-builder-message")
+    public Publisher<Message<String>> sourceForSubscriberBuilderMessage() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Incoming("subscriber-payload")
-  public Subscriber<String> subscriberOfPayloads() {
-    increment("subscriber-payload");
-    return ReactiveStreams.<String>builder().forEach(p -> add("subscriber-payload", p)).build();
-  }
+    @Incoming("subscriber-builder-message")
+    public SubscriberBuilder<Message<String>, Void> subscriberBuilderOfMessages() {
+        increment("subscriber-builder-message");
+        return ReactiveStreams.<Message<String>>builder()
+            .forEach(m -> add("subscriber-builder-message", m.getPayload()));
+    }
 
+    @Outgoing("subscriber-payload")
+    public Publisher<Message<String>> sourceForSubscribePayload() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Outgoing("void-payload")
-  public Publisher<Message<String>> sourceForVoidPayload() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Incoming("subscriber-payload")
+    public Subscriber<String> subscriberOfPayloads() {
+        increment("subscriber-payload");
+        return ReactiveStreams.<String>builder().forEach(p -> add("subscriber-payload", p)).build();
+    }
 
-  @Incoming("void-payload")
-  public void consumePayload(String payload) {
-    increment("void-payload");
-    add("void-payload", payload);
-  }
+    @Outgoing("subscriber-builder-payload")
+    public Publisher<Message<String>> sourceForSubscriberBuilderPayload() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Outgoing("string-payload")
-  public Publisher<Message<String>> sourceForStringPayload() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Incoming("subscriber-builder-payload")
+    public SubscriberBuilder<String, Void> subscriberBuilderOfPayloads() {
+        increment("subscriber-builder-payload");
+        return ReactiveStreams.<String>builder().forEach(p -> add("subscriber-builder-payload", p));
+    }
 
-  @Incoming("string-payload")
-  public String consumePayloadsAndReturnSomething(String payload) {
-    increment("string-payload");
-    add("string-payload", payload);
-    return payload;
-  }
+    @Outgoing("void-payload")
+    public Publisher<Message<String>> sourceForVoidPayload() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Outgoing("cs-void-message")
-  public Publisher<Message<String>> sourceForCsVoidMessage() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Incoming("void-payload")
+    public void consumePayload(String payload) {
+        increment("void-payload");
+        add("void-payload", payload);
+    }
 
-  @Incoming("cs-void-message")
-  public CompletionStage<Void> consumeMessageAndReturnCompletionStageOfVoid(Message<String> message) {
-    increment("cs-void-message");
-    return CompletableFuture.runAsync(() -> add("cs-void-message", message.getPayload()), EXECUTOR);
-  }
+    @Outgoing("string-payload")
+    public Publisher<Message<String>> sourceForStringPayload() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Outgoing("cs-void-payload")
-  public Publisher<Message<String>> sourceForCsVoidPayload() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Incoming("string-payload")
+    public String consumePayloadsAndReturnSomething(String payload) {
+        increment("string-payload");
+        add("string-payload", payload);
+        return payload;
+    }
 
-  @Incoming("cs-void-payload")
-  public CompletionStage<Void> consumePayloadAndReturnCompletionStageOfVoid(String payload) {
-    increment("cs-void-payload");
-    return CompletableFuture.runAsync(() -> add("cs-void-payload", payload), EXECUTOR);
-  }
+    @Outgoing("cs-void-message")
+    public Publisher<Message<String>> sourceForCsVoidMessage() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Outgoing("cs-string-message")
-  public Publisher<Message<String>> sourceForCsStringMessage() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Incoming("cs-void-message")
+    public CompletionStage<Void> consumeMessageAndReturnCompletionStageOfVoid(Message<String> message) {
+        increment("cs-void-message");
+        return CompletableFuture.runAsync(() -> add("cs-void-message", message.getPayload()), EXECUTOR);
+    }
 
-  @Incoming("cs-string-message")
-  public CompletionStage<String> consumeMessageAndReturnCompletionStageOfString(Message<String> message) {
-    increment("cs-string-message");
-    return CompletableFuture.supplyAsync(() -> {
-      add("cs-string-message", message.getPayload());
-      return "something";
-    }, EXECUTOR);
-  }
+    @Outgoing("cs-void-payload")
+    public Publisher<Message<String>> sourceForCsVoidPayload() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  @Outgoing("cs-string-payload")
-  public Publisher<Message<String>> sourceForCsStringPayload() {
-    return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-  }
+    @Incoming("cs-void-payload")
+    public CompletionStage<Void> consumePayloadAndReturnCompletionStageOfVoid(String payload) {
+        increment("cs-void-payload");
+        return CompletableFuture.runAsync(() -> add("cs-void-payload", payload), EXECUTOR);
+    }
 
-  @Incoming("cs-string-payload")
-  public CompletionStage<String> consumePayloadAndReturnCompletionStageOfString(String payload) {
-    increment("cs-string-payload");
-    return CompletableFuture.supplyAsync(() -> {
-      add("cs-string-payload", payload);
-      return "something";
-    }, EXECUTOR);
-  }
+    @Outgoing("cs-string-message")
+    public Publisher<Message<String>> sourceForCsStringMessage() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-  private void add(String key, String value) {
-    collector.computeIfAbsent(key, x -> new CopyOnWriteArrayList<>()).add(value);
-  }
+    @Incoming("cs-string-message")
+    public CompletionStage<String> consumeMessageAndReturnCompletionStageOfString(Message<String> message) {
+        increment("cs-string-message");
+        return CompletableFuture.supplyAsync(() -> {
+            add("cs-string-message", message.getPayload());
+            return "something";
+        }, EXECUTOR);
+    }
 
-  void verify() {
-    await().until(() -> collector.size() == 8);
-    assertThat(collector).hasSize(8).allSatisfy((k, v) -> assertThat(v).containsExactlyElementsOf(EXPECTED));
-    assertThat(counters.get("subscriber-message")).hasValue(1);
-    assertThat(counters.get("subscriber-payload")).hasValue(1);
+    @Outgoing("cs-string-payload")
+    public Publisher<Message<String>> sourceForCsStringPayload() {
+        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
+    }
 
-    assertThat(counters.get("void-payload")).hasValue(EXPECTED.size());
-    assertThat(counters.get("string-payload")).hasValue(EXPECTED.size());
+    @Incoming("cs-string-payload")
+    public CompletionStage<String> consumePayloadAndReturnCompletionStageOfString(String payload) {
+        increment("cs-string-payload");
+        return CompletableFuture.supplyAsync(() -> {
+            add("cs-string-payload", payload);
+            return "something";
+        }, EXECUTOR);
+    }
 
-    assertThat(counters.get("cs-void-payload")).hasValue(EXPECTED.size());
-    assertThat(counters.get("cs-string-payload")).hasValue(EXPECTED.size());
-    assertThat(counters.get("cs-void-message")).hasValue(EXPECTED.size());
-    assertThat(counters.get("cs-string-message")).hasValue(EXPECTED.size());
-  }
+    private void add(String key, String value) {
+        collector.computeIfAbsent(key, x -> new CopyOnWriteArrayList<>()).add(value);
+    }
 
+    void verify() {
+        await().until(() -> collector.size() == 10);
+        assertThat(collector).hasSize(10).allSatisfy((k, v) -> assertThat(v).containsExactlyElementsOf(EXPECTED));
+        assertThat(counters.get("subscriber-message")).hasValue(1);
+        assertThat(counters.get("subscriber-payload")).hasValue(1);
+        assertThat(counters.get("subscriber-builder-message")).hasValue(1);
+        assertThat(counters.get("subscriber-builder-payload")).hasValue(1);
+
+        assertThat(counters.get("void-payload")).hasValue(EXPECTED.size());
+        assertThat(counters.get("string-payload")).hasValue(EXPECTED.size());
+
+        assertThat(counters.get("cs-void-payload")).hasValue(EXPECTED.size());
+        assertThat(counters.get("cs-string-payload")).hasValue(EXPECTED.size());
+        assertThat(counters.get("cs-void-message")).hasValue(EXPECTED.size());
+        assertThat(counters.get("cs-string-message")).hasValue(EXPECTED.size());
+    }
 
 }


### PR DESCRIPTION
The current TCK didn't check the method returning `SubscriberBuilder` instances. 
This PR adds the missing tests.

Also, it fixes 2 concurrency issues in the Publisher tests and Dependant scope test.