### PR TITLE
Fix TCK after the integration of the @Connector qualifier

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/ConnectorLiteral.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/ConnectorLiteral.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.spi;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * Supports inline instantiation of the {@link Connector} qualifier.
+ */
+public final class ConnectorLiteral extends AnnotationLiteral<Connector> implements Connector {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String value;
+
+    /**
+     * Creates a new instance of {@link ConnectorLiteral}.
+     *
+     * @param value the name of the connector, must not be {@code null}, must not be {@code blank}
+     * @return the {@link ConnectorLiteral} instance.
+     */
+    public static Connector of(String value) {
+        return new ConnectorLiteral(value);
+    }
+
+    /**
+     * Creates a new instance of {@link ConnectorLiteral}.
+     * Users should use the {@link #of(String)} method to create instances.
+     *
+     * @param value the value.
+     */
+    private ConnectorLiteral(String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return the connector name.
+     */
+    public String value() {
+        return value;
+    }
+}
+

--- a/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/ConnectorTest.java
+++ b/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/ConnectorTest.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.microprofile.reactive.messaging.tck.connector;
 
+import org.eclipse.microprofile.reactive.messaging.spi.ConnectorLiteral;
 import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -28,6 +29,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import java.util.ServiceLoader;
 
@@ -41,7 +43,7 @@ import static org.awaitility.Awaitility.await;
 public class ConnectorTest {
 
     @Inject
-    private DummyConnector connector;
+    private BeanManager manager;
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
@@ -55,6 +57,8 @@ public class ConnectorTest {
 
     @Test
     public void checkConnector() {
+        DummyConnector connector = manager.createInstance()
+            .select(DummyConnector.class, ConnectorLiteral.of("Dummy")).get();
         await().until(() -> connector.elements().size() == 10);
         assertThat(connector.elements()).containsExactly("A", "B", "C", "D", "E", "F", "G", "H", "I", "J");
     }

--- a/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantBeans.java
+++ b/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantBeans.java
@@ -34,14 +34,15 @@ public class DependantBeans {
     private static final AtomicInteger COUNTER = new AtomicInteger();
     private final int id;
     private List<Integer> list = new CopyOnWriteArrayList<>();
-    private static final List<Integer> STATIC_LIST = new CopyOnWriteArrayList<>();
+    private static final List<String> INSTANCES = new CopyOnWriteArrayList<>();
 
     public DependantBeans() {
+        INSTANCES.add(this.toString());
         id = COUNTER.getAndIncrement();
     }
 
-    static List<Integer> getStaticList() {
-        return STATIC_LIST;
+    static List<String> getInstances() {
+        return INSTANCES;
     }
 
     @Outgoing("source")
@@ -57,7 +58,6 @@ public class DependantBeans {
 
     @Incoming("output")
     public void sink(int v) {
-        STATIC_LIST.add(v);
         list.add(v);
     }
 

--- a/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantScopeTest.java
+++ b/core-tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantScopeTest.java
@@ -42,10 +42,9 @@ public class DependantScopeTest extends TckBase {
 
     @Test
     public void verify() {
-        await().until(() -> DependantBeans.getStaticList().size() == 1);
+        // the injected instance, the source, the sink, the processor
+        await().until(() -> DependantBeans.getInstances().size() == 4);
         assertThat(bean.getList()).isEmpty();
-        assertThat(DependantBeans.getStaticList()).hasSize(1);
-        assertThat(DependantBeans.getStaticList().get(0)).isGreaterThan(1);
     }
 
 }


### PR DESCRIPTION
This PR:

* Fixes the TCK after the `@Connector` integration
* Adds a `ConnectorLiteral`, not because it's complicated, but because all implementations would need one. (discussed during the hangout, and forgot about it)
* Re-implements the DependantScope test as it was very brittle