### PR TITLE
Forbid post-processing ack where a Processor produces a Message

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -780,7 +780,6 @@ Processor<Message<I>, Message<O>> method()
 ----
 | Pre-Processing
 | None, Pre-Processing, Manual
-Post-Processing can be optionally supported by implementations, however it requires a 1:1 mapping between the incoming element and the outgoing element.
 
 | 
 [source,java]
@@ -802,7 +801,6 @@ ProcessorBuilder<Message<I>, Message<O>> method();
 ----
 | Pre-Processing
 | None, Pre-Processing, Manual
-Post-Processing can be optionally supported by implementations, however it requires a 1:1 mapping between the incoming element and the outgoing element.
 
 |
 [source,java]


### PR DESCRIPTION
If the user's processor produces the message, the reactive messaging
implementation cannot determine when that message is acknowledged
without wrapping it and hiding the actual class of the Message.

I think this was missing from #44