### PR TITLE
Declare the CDI dependency in the `provided` scope and exclude EL

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,6 +52,13 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.el</groupId>
+                    <artifactId>javax.el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Following the discussion on https://github.com/eclipse/microprofile/issues/56, this commit changes the scope of the CDI dependency to `provided` and excludes explicitly the dependency on EL

