### PR TITLE
Fix the ApplicationScopedTest

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/ApplicationBeans.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/ApplicationBeans.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.reactivestreams.Publisher;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,11 +33,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ApplicationBeans {
 
   private static final AtomicInteger COUNTER = new AtomicInteger();
-  private final int id;
+  private int id;
   private List<Integer> list = new ArrayList<>();
   private static final List<Integer> STATIC_LIST = new ArrayList<>();
 
-  public ApplicationBeans() {
+  @PostConstruct
+  private void init() {
     id = COUNTER.getAndIncrement();
   }
 


### PR DESCRIPTION
Move the initialization of the the id field in ApplicationBeans from the
constructor to a PostConstruct method.

The test that uses this class verifies that only one instance of the
ApplicationScoped bean is created.

However, because this is a normal scoped bean, the container may need to
create client proxies for this class and when it constructs one of
these, it will call the zero-arg constructor.

Therefore, although only one instance of the bean will be created, its
constructor may be called more than once.

Setting up the id in a PostConstruct method avoids this issue because
the PostConstruct method won't be called when creating a client proxy.