### PR TITLE
Add an unwrap method to the Message interface.

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -80,4 +80,29 @@ public interface Message<T> {
     default CompletionStage<Void> ack() {
         return CompletableFuture.completedFuture(null);
     }
+
+    /**
+     * Returns an object of the specified type to allow access to the connector-specific {@link Message} implementation.
+     * If the {@link Message} implementation does not support the target class, an {@link IllegalArgumentException}
+     * should be raised.
+     * The default implementation only supports the {@link Message} class as argument. When a connector provides
+     * its own {@link Message} implementation, it should override this method to support the specific type.
+     *
+     * @param unwrapType the class of the object to be returned, must not be {@code null}
+     * @param <C> the target type
+     * @return an instance of the specified class
+     * @throws IllegalArgumentException if the current {@link Message} instance does not support the call
+     */
+    @SuppressWarnings({"unchecked"})
+    default <C> C unwrap(Class<C> unwrapType) {
+        if (unwrapType == null) {
+            throw new NullPointerException("The target class must not be `null`");
+        }
+        if (Message.class.equals(unwrapType)) {
+            return (C) this;
+        }
+        throw new IllegalArgumentException("Cannot unwrap an instance of " + this.getClass().getName()
+            + " to " + unwrapType.getName());
+
+    }
 }

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -96,13 +96,16 @@ public interface Message<T> {
     @SuppressWarnings({"unchecked"})
     default <C> C unwrap(Class<C> unwrapType) {
         if (unwrapType == null) {
-            throw new NullPointerException("The target class must not be `null`");
+            throw new IllegalArgumentException("The target class must not be `null`");
         }
-        if (Message.class.equals(unwrapType)) {
-            return (C) this;
+        try {
+            return unwrapType.cast(this);
         }
-        throw new IllegalArgumentException("Cannot unwrap an instance of " + this.getClass().getName()
-            + " to " + unwrapType.getName());
+        catch (ClassCastException e) {
+            throw new IllegalArgumentException("Cannot unwrap an instance of " + this.getClass().getName()
+                + " to " + unwrapType.getName(), e);
+        }
+
 
     }
 }

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -82,11 +82,14 @@ public interface Message<T> {
     }
 
     /**
-     * Returns an object of the specified type to allow access to the connector-specific {@link Message} implementation.
-     * If the {@link Message} implementation does not support the target class, an {@link IllegalArgumentException}
-     * should be raised.
-     * The default implementation only supports the {@link Message} class as argument. When a connector provides
-     * its own {@link Message} implementation, it should override this method to support the specific type.
+     * Returns an object of the specified type to allow access to the connector-specific {@link Message} implementation,
+     * and other classes. For example, a Kafka connector could implement this method to allow unwrapping to a specific
+     * Kafka message implementation, or to {@code ConsumerRecord} and {@code ProducerRecord}. If the {@link Message}
+     * implementation does not support the target class, an {@link IllegalArgumentException} should be raised.
+     *
+     * The default implementation tries to <em>cast</em> the current {@link Message} instance to the target class.
+     * When a connector provides its own {@link Message} implementation, it should override this method to support
+     * specific types.
      *
      * @param unwrapType the class of the object to be returned, must not be {@code null}
      * @param <C> the target type


### PR DESCRIPTION
This would allow users of a connector to avoid casting. Instead, the user would use the `unwrap` method. For instance: `KafkaMessage myMessage = msg.unwrap(KafkaMessage.class)`.

The default implementation only supports `Message` as parameter. Connector implementation would need to override the method.
