### PR TITLE
Fix #62 - Exclude the EL transitive dependency from CDI

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -72,6 +72,12 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.el</groupId>
+                    <artifactId>javax.el-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>


### PR DESCRIPTION
Was mostly done everywhere except in the TCK.

