### PR TITLE
OSGi: remove non-existent microprofile.reactive.streams import

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -2,7 +2,6 @@
     org.eclipse.microprofile.*
 
 Import-Package: \
-    org.eclipse.microprofile.reactive.streams;version="[1.0.0,2)", \
     *
 
 Bundle-SymbolicName: org.eclipse.microprofile.reactive.messaging


### PR DESCRIPTION
Resolves #69

The OSGi metadata for the api artifact imports a nonexistent package,
making it difficult to deploy this bundle in an OSGi runtime. This
commit removes the explicit import of that package, relying instead on
the dynamic bnd import mechanism.