### PR TITLE
Clarify @Incoming method signatures

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -383,8 +383,6 @@ The payload is automatically extracted from the inflight messages using `Message
 void method(I payload)
 ----
 | Consumes the _payload_.
-The method can return `void` or any object or `null`. 
-The returned value is ignored. 
 | This method is called for every `Message<I>` instance transiting on the channel `channel`. 
 The payload is automatically extracted from the inflight messages using `Message.getPayload()`.
 The user method is never called concurrently and so must return before being called with the next payload.
@@ -393,7 +391,7 @@ The user method is never called concurrently and so must return before being cal
 [source,java]
 ----
 @Incoming("channel")
-CompletionStage<?> method(Message<I> msg)
+CompletionStage<Void> method(Message<I> msg)
 ----
 | Consumes the `Message` 
 | This method is called for every `Message<I>` instance transiting on the channel `channel`. 

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoid.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoid.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.signatures.invalid;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Publisher;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class IncomingReturningNonVoid {
+
+    @Outgoing("invalid")
+    public Publisher<Message<String>> sourceForStringPayload() {
+        return ReactiveStreams.of("a", "b", "c").map(Message::of).buildRs();
+    }
+
+    @Incoming("invalid")
+    public String invalid(String payload) {
+        return payload;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoidCompletionStage.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoidCompletionStage.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.signatures.invalid;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
+import org.reactivestreams.Publisher;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.concurrent.CompletionStage;
+
+@ApplicationScoped
+public class IncomingReturningNonVoidCompletionStage {
+
+    @Outgoing("invalid")
+    public Publisher<Message<String>> sourceForStringPayload() {
+        return ReactiveStreams.of("a", "b", "c").map(Message::of).buildRs();
+    }
+
+    @Incoming("invalid")
+    public CompletionStage<String> invalid(Message<String> m) {
+        return m.ack().thenApply(x -> "foo");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/InvalidSubscriberSignatureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/InvalidSubscriberSignatureTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.signatures.invalid;
+
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.spi.DefinitionException;
+import java.util.ServiceLoader;
+
+@RunWith(Arquillian.class)
+public class InvalidSubscriberSignatureTest {
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(managed = false, name = "incoming-returning-object")
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    public static Archive<JavaArchive> incomingReturningNonVoid() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(IncomingReturningNonVoid.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Test
+    public void checkThatIncomingShouldNotReturnObject() {
+        deployer.deploy("incoming-returning-object");
+    }
+
+    @Deployment(managed = false, name = "incoming-returning-non-void-cs")
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    public static Archive<JavaArchive> incomingReturningNonVoidCompletionStage() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(IncomingReturningNonVoidCompletionStage.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Test
+    public void checkThatIncomingShouldNotReturnNonVoidCompletionStagw() {
+        deployer.deploy("incoming-returning-non-void-cs");
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/InvalidSubscriberSignatureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/InvalidSubscriberSignatureTest.java
@@ -68,7 +68,7 @@ public class InvalidSubscriberSignatureTest {
     }
 
     @Test
-    public void checkThatIncomingShouldNotReturnNonVoidCompletionStagw() {
+    public void checkThatIncomingShouldNotReturnNonVoidCompletionStage() {
         deployer.deploy("incoming-returning-non-void-cs");
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberBean.java
@@ -121,18 +121,6 @@ public class SubscriberBean {
         add("void-payload", payload);
     }
 
-    @Outgoing("string-payload")
-    public Publisher<Message<String>> sourceForStringPayload() {
-        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-    }
-
-    @Incoming("string-payload")
-    public String consumePayloadsAndReturnSomething(String payload) {
-        increment("string-payload");
-        add("string-payload", payload);
-        return payload;
-    }
-
     @Outgoing("cs-void-message")
     public Publisher<Message<String>> sourceForCsVoidMessage() {
         return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
@@ -155,53 +143,20 @@ public class SubscriberBean {
         return CompletableFuture.runAsync(() -> add("cs-void-payload", payload), EXECUTOR);
     }
 
-    @Outgoing("cs-string-message")
-    public Publisher<Message<String>> sourceForCsStringMessage() {
-        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-    }
-
-    @Incoming("cs-string-message")
-    public CompletionStage<String> consumeMessageAndReturnCompletionStageOfString(Message<String> message) {
-        increment("cs-string-message");
-        return CompletableFuture.supplyAsync(() -> {
-            add("cs-string-message", message.getPayload());
-            return "something";
-        }, EXECUTOR);
-    }
-
-    @Outgoing("cs-string-payload")
-    public Publisher<Message<String>> sourceForCsStringPayload() {
-        return ReactiveStreams.fromIterable(EXPECTED).map(Message::of).buildRs();
-    }
-
-    @Incoming("cs-string-payload")
-    public CompletionStage<String> consumePayloadAndReturnCompletionStageOfString(String payload) {
-        increment("cs-string-payload");
-        return CompletableFuture.supplyAsync(() -> {
-            add("cs-string-payload", payload);
-            return "something";
-        }, EXECUTOR);
-    }
-
     private void add(String key, String value) {
         collector.computeIfAbsent(key, x -> new CopyOnWriteArrayList<>()).add(value);
     }
 
     void verify() {
-        await().until(() -> collector.size() == 10);
-        assertThat(collector).hasSize(10).allSatisfy((k, v) -> assertThat(v).containsExactlyElementsOf(EXPECTED));
+        await().until(() -> collector.size() == 7);
+        assertThat(collector).hasSize(7).allSatisfy((k, v) -> assertThat(v).containsExactlyElementsOf(EXPECTED));
         assertThat(counters.get("subscriber-message")).hasValue(1);
         assertThat(counters.get("subscriber-payload")).hasValue(1);
         assertThat(counters.get("subscriber-builder-message")).hasValue(1);
         assertThat(counters.get("subscriber-builder-payload")).hasValue(1);
-
         assertThat(counters.get("void-payload")).hasValue(EXPECTED.size());
-        assertThat(counters.get("string-payload")).hasValue(EXPECTED.size());
-
         assertThat(counters.get("cs-void-payload")).hasValue(EXPECTED.size());
-        assertThat(counters.get("cs-string-payload")).hasValue(EXPECTED.size());
         assertThat(counters.get("cs-void-message")).hasValue(EXPECTED.size());
-        assertThat(counters.get("cs-string-message")).hasValue(EXPECTED.size());
     }
 
 }


### PR DESCRIPTION
Fix #79

* Remove tests using non-supported signatures
* Add new tests in the TCK to be sure these non-supported signatures are detected and reported using CDI Definition Exception
* Clarify the spec about these signatures