### PR TITLE
Update default ack strategy when dealing with Message

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Acknowledgment.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Acknowledgment.java
@@ -31,7 +31,7 @@ import java.lang.annotation.RetentionPolicy;
  * <ul>
  *     <li><code> @Incoming("channel") void method(I payload)</code>: Post-processing (default), Pre-processing, None</li>
  *     <li><code> @Incoming("channel") CompletionStage&lt;?&gt; method(I payload)</code>: Post-processing (default), Pre-processing, None</li>
- *     <li><code> @Incoming("in") @Outgoing("out") Message&lt;O&gt; method(Message&lt;I&gt; msg)</code>: Pre-processing (default), None, Manual</li>
+ *     <li><code> @Incoming("in") @Outgoing("out") Message&lt;O&gt; method(Message&lt;I&gt; msg)</code>: , Manual (default), Pre-processing, None</li>
  *     <li><code> @Incoming("in") @Outgoing("out") O method(I payload)</code>: Post-Processing (default), Pre-processing, None</li>
  * </ul>
  *

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -718,7 +718,7 @@ The following table indicates the defaults and supported acknowledgement for eac
 @Incoming("channel")
 Subscriber<Message<I>> method()
 ----
-| Post-Processing	
+| Manual
 | None, Pre-Processing, Post-Processing (when the `onNext` method returns), Manual
 
 |
@@ -736,7 +736,7 @@ Subscriber<I> method()
 @Incoming("channel") 
 SubscriberBuilder<Message<I>, Void> method()
 ----
-| Post-Processing	
+| Manual
 | None, Pre-Processing, Post-Processing (when the `onNext` method returns), Manual
 
 
@@ -783,7 +783,7 @@ CompletionStage<?> method(I payload)
 @Outgoing("out")
 Processor<Message<I>, Message<O>> method()
 ----
-| Pre-Processing
+| Manual
 | None, Pre-Processing, Manual
 
 | 
@@ -804,7 +804,7 @@ Post-Processing can be optionally supported by implementations, however it requi
 @Outgoing("out") 
 ProcessorBuilder<Message<I>, Message<O>> method();
 ----
-| Pre-Processing
+| Manual
 | None, Pre-Processing, Manual
 
 |
@@ -825,7 +825,7 @@ Post-Processing can be optionally supported by implementations, however it requi
 @Outgoing("out") 
 Publisher<Message<O>> method(Message<I> msg)
 ----
-| Pre-Processing
+| Manual
 | None, Manual, Pre-Processing
 
 |
@@ -845,7 +845,7 @@ Publisher<O> method(I payload)
 @Outgoing("out") 
 PublisherBuilder<Message<O>> method(Message<I> msg)
 ----
-| Pre-Processing
+| Manual
 | None, Manual, Pre-Processing
 
 |
@@ -1012,6 +1012,21 @@ public O process(I payload) {
 }
 ----
 
+`PRE_PROCESSING` can also be used with `Messages`:
+
+[source, java]
+----
+@Incoming("in")
+@Outgoing("out")
+@Acknowledgment(Acknowledgment.Strategy.PRE_PROCESSING)
+public Message<O> process(Message<I> msg) {
+  return Message.of(convert(msg.getPayload()));
+}
+----
+
+In this case, the message `msg` is acknowledged before the method being called.
+The outgoing message (returned by the method) does not have to chain the acknowledgment.
+
 The `NONE` strategy indicates that the incoming message is not acknowledged and the acknowledgment of the outgoing message would not acknowledge the incoming message anymore.
 The `NONE` strategy may be used when the incoming messages are acknowledged in another location, or a different mechanism..
 
@@ -1032,6 +1047,7 @@ The following snippet is particularly useful for processing messages that are al
 ----
 @Incoming("in")
 @Outgoing("out")
+@Acknowledgment(Acknowledgment.Strategy.MANUAL) // Default strategy 
 public Message<O> process(Message<I> msg) {
   return Message.of(convert(msg.getPayload()), msg::ack);
 }

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -764,7 +764,7 @@ void method(I payload)
 @Incoming("channel")
 CompletionStage<?> method(Message<I> msg)
 ----
-| Post-Processing
+| Manual
 | None, Pre-Processing, Post-Processing (when the returned `CompletionStage` is completed), Manual
 
 |
@@ -866,7 +866,7 @@ PublisherBuilder<O> method(I payload)
 @Outgoing("out") 
 Message<O> method(Message<I> msg)
 ----
-| Pre-Processing
+| Manual
 | None, Manual, Pre-Processing
 
 |
@@ -883,17 +883,17 @@ O method(I payload)
 [source,java]
 ----
 @Incoming("in")
-@Outgoing("out") 
+@Outgoing("out")
 CompletionStage<Message<O>> method(Message<I> msg)
 ----
-| Pre-Processing
+| Manual
 | None, Manual, Pre-Processing
 
 |
 [source,java]
 ----
 @Incoming("in")
-@Outgoing("out") 
+@Outgoing("out")
 CompletionStage<O> method(I payload)
 ----
 | Post-Processing
@@ -906,7 +906,7 @@ CompletionStage<O> method(I payload)
 @Outgoing("out") 
 Publisher<Message<O>> method(Publisher<Message<I>> pub)
 ----
-| Pre-Processing
+| Manual
 | None, Manual, Pre-Processing
 
 |
@@ -916,7 +916,7 @@ Publisher<Message<O>> method(Publisher<Message<I>> pub)
 @Outgoing("out") 
 PublisherBuilder<Message<O>> method(PublisherBuilder<Message<I>> pub)
 ----
-| Pre-Processing
+| Manual
 | None, Manual, Pre-Processing
 
 |
@@ -1025,14 +1025,13 @@ public O process(I payload) {
 }
 ----
 
-The `MANUAL` strategy indicates that the acknowledgment is managed by the user code. 
+The `MANUAL` strategy indicates that the acknowledgment is managed by the user code.
 The following snippet is particularly useful for processing messages that are also being sent to a destination, as the implementation must not invoke `ack` until after the outgoing message has been sent to the destination:
 
 [source, java]
 ----
 @Incoming("in")
 @Outgoing("out")
-@Acknowledgment(Acknowledgment.Strategy.MANUAL)
 public Message<O> process(Message<I> msg) {
   return Message.of(convert(msg.getPayload()), msg::ack);
 }


### PR DESCRIPTION
When consuming/producing Messages, the default acknowledgment should be MANUAL instead of PRE_PROCESSING.

When using messages, you should have full control. You can still set the strategy to `PRE` or `POST`. It was creating a non-homogeneous experience. So, with this change, the experience is homogeneous. 