### PR TITLE
Move metrics to the base scope

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -1198,7 +1198,7 @@ The connector is responsible for the acknowledgment of the incoming and outgoing
 
 When MicroProfile Reactive Messaging is used in an environment where MicroProfile Metrics is enabled, the Reactive Messaging implementation automatically produces metrics.
 
-The following metrics are produced for each channel declared by the application
+The following metrics are produced for each channel declared by the application and are added to the `base` scope.
 
 [cols="8,3,4,9"]
 |===

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/MetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/MetricsTest.java
@@ -32,6 +32,8 @@ import org.awaitility.Awaitility;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricRegistry.Type;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.spi.Connector;
 import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
@@ -66,6 +68,7 @@ public class MetricsTest {
     private TestConnector testConnector;
     
     @Inject
+    @RegistryType(type = Type.BASE)
     private MetricRegistry metricRegistry;
     
     @Inject


### PR DESCRIPTION
Specify the scope in the spec and update TCK to expect metrics in the `BASE` scope

Fixes #93