### PR TITLE
Fix copyright header automation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 // information regarding copyright ownership.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 image:https://badges.gitter.im/eclipse/microprofile-reactive.svg[link="https://gitter.im/eclipse/microprofile-reactive"]
 
 = Reactive Messaging for MicroProfile

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Acknowledgment.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Acknowledgment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Incoming.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Incoming.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Outgoing.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Outgoing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/Connector.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/Connector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/ConnectorFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/ConnectorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/ConnectorLiteral.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/ConnectorLiteral.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/IncomingConnectorFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/IncomingConnectorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/OutgoingConnectorFactory.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/OutgoingConnectorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/spi/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/approach.asciidoc
+++ b/approach.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/mp_checkstyle_rules.xml
+++ b/mp_checkstyle_rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -284,14 +284,38 @@
             </plugin>
 
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>timestamp-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>current.year</name>
+                            <pattern>yyyy</pattern>
+                            <locale>en_US</locale>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <header>src/license/license.txt</header>
+                    <headerSections>
+                        <headerSection>
+                            <key>COPYRIGHT_DATE</key>
+                            <defaultValue>${current.year}</defaultValue>
+                            <ensureMatch>(\d{4}[,\-] ?)?\d{4}</ensureMatch>
+                        </headerSection>
+                    </headerSections>
                     <properties>
-                        <year>2019</year>
                         <owner>Eclipse MicroProfile</owner>
                     </properties>
                     <mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
                         <headerSection>
                             <key>COPYRIGHT_DATE</key>
                             <defaultValue>${current.year}</defaultValue>
-                            <ensureMatch>(\d{4}[,\-] ?)?\d{4}</ensureMatch>
+                            <ensureMatch>(\d{4}, ?)?\d{4}</ensureMatch>
                         </headerSection>
                     </headerSections>
                     <properties>
@@ -320,7 +320,15 @@
                     </properties>
                     <mapping>
                         <asciidoc>DOUBLESLASH_STYLE</asciidoc>
+                        <adoc>DOUBLESLASH_STYLE</adoc>
                     </mapping>
+                    <excludes>
+                        <exclude>LICENSE</exclude>
+                        <exclude>NOTICE</exclude>
+                        <exclude>.gitattributes</exclude>
+                        <exclude>**/bnd.bnd</exclude>
+                        <exclude>**/.checkstyle</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/site.yaml
+++ b/site.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/spec/src/main/asciidoc/license-alv2.asciidoc
+++ b/spec/src/main/asciidoc/license-alv2.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -28,7 +28,7 @@ Status: {revremark}
 
 Release: {revdate}
 
-Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/spec/src/main/asciidoc/microprofile-reactive-messaging-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-reactive-messaging-spec.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/spec/src/main/asciidoc/rationale.asciidoc
+++ b/spec/src/main/asciidoc/rationale.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/src/license/license.txt
+++ b/src/license/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${project.inceptionYear}-${year} Contributors to the Eclipse Foundation
+Copyright (c) COPYRIGHT_DATE Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.

--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -5,7 +5,7 @@
 // information regarding copyright ownership.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
 = MicroProfile Reactive Messaging TCK
 
 This project contains the TCK for Reactive Messaging

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ArchiveExtender.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ArchiveExtender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/BeanWithChain.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/BeanWithChain.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ProcessorChainTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ProcessorChainTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/SimpleIncomingBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/SimpleIncomingBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/SimpleIncomingTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/SimpleIncomingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/StringSource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/StringSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/TckBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/TckBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ValueCollector.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/ValueCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/ConnectorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/ConnectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/DummyConnector.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/DummyConnector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/MissingConnectorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/MissingConnectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/MyProcessor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/MyProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/MyProcessorWithBadStreamName.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/connector/MyProcessorWithBadStreamName.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/AssertJArchiveAppender.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/AssertJArchiveAppender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/AwaitilityArchiveAppender.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/AwaitilityArchiveAppender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/ReactiveMessagingLoadableExtension.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/ReactiveMessagingLoadableExtension.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/RxJavaArchiveAppender.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/extension/RxJavaArchiveAppender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithBadOutgoingSignature.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithBadOutgoingSignature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyIncoming.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyIncoming.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyOutgoing.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyOutgoing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithIncompleteChain.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithIncompleteChain.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/InvalidConfigurationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/InvalidConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/ConfigAsset.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/ConfigAsset.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/MetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/MetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/MetricsTestBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/MetricsTestBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/TestConnector.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/metrics/TestConnector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/ApplicationBeans.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/ApplicationBeans.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/ApplicationScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/ApplicationScopeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantBeans.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantBeans.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantScopeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/scope/DependantScopeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoid.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoid.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoidCompletionStage.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/IncomingReturningNonVoidCompletionStage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/InvalidSubscriberSignatureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/invalid/InvalidSubscriberSignatureTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/DirectProcessorBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/DirectProcessorBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/ProcessorBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/ProcessorBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/ProcessorShapeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/ProcessorShapeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/PublisherBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/PublisherBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/TransformerBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/processors/TransformerBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/PublisherBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/PublisherBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/PublisherShapeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/PublisherShapeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/VerifierForPublisherBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/publishers/VerifierForPublisherBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberShapeTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/signatures/subscribers/SubscriberShapeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/resources/org/eclipse/microprofile/reactive/messaging/tck/connector/connector-config.properties
+++ b/tck/src/main/resources/org/eclipse/microprofile/reactive/messaging/tck/connector/connector-config.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2019 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.


### PR DESCRIPTION
Update the configuration of the license header plugin
 * Newly created files have a copyright header added with the current year
 * Existing files do not have the date altered

Update existing files to match the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#ip-copyright-headers)

Fixes #109 