### PR TITLE
Set imagesdir so that images appear on github

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -17,6 +17,7 @@
 // limitations under the License.
 //
 
+:imagesdir: images
 [[reactivemessagingarchitecture]]
 == Architecture
 

--- a/spec/src/main/asciidoc/microprofile-reactive-messaging-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-reactive-messaging-spec.asciidoc
@@ -28,6 +28,7 @@
 :toc: left
 :toclevels: 4
 :sectnumlevels: 4
+:imagesdir: images
 ifdef::backend-pdf[]
 :pagenums:
 endif::[]

--- a/spec/src/main/asciidoc/rationale.asciidoc
+++ b/spec/src/main/asciidoc/rationale.asciidoc
@@ -17,6 +17,7 @@
 // limitations under the License.
 //
 
+:imagesdir: images
 [[reactivemessagingrationale]]
 == Rationale
 


### PR DESCRIPTION
The maven plugin defaults imagesdir to "images", but github doesn't do
that when it renders the preview for asciidoc files.

This change allows images to show up correctly in github previews, as
well as in the built documents.

Github also doesn't handle includes, so you can only view each file
individually so we need to specify imagesdir in every file.

Fixes #105 