### PR TITLE
Negative Acknowledgement

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Emitter.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Emitter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,7 +43,7 @@ import java.util.concurrent.CompletionStage;
  * messages are sent using the `Emitter` when a downstream subscriber hasn't requested
  * more messages.
  *
- * @param <T> type of payload 
+ * @param <T> type of payload
  */
 public interface Emitter<T> {
 
@@ -55,6 +55,7 @@ public interface Emitter<T> {
      *
      * @param msg the <em>thing</em> to send, must not be {@code null}
      * @return the {@code CompletionStage}, which will be completed when the message for this payload is acknowledged.
+     *         If the emitted message is nacked, the produced completion stage is completed exceptionally.
      * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
      *                               {@link OnOverflow.Strategy#THROW_EXCEPTION THROW_EXCEPTION} or {@link OnOverflow.Strategy#BUFFER BUFFER} is
      *                               configured and the emitter overflows.
@@ -63,7 +64,7 @@ public interface Emitter<T> {
 
     /**
      * Sends a message to the channel.
-     * 
+     *
      * @param <M> the <em>Message</em> type
      * @param msg the <em>Message</em> to send, must not be {@code null}
      * @throws IllegalStateException if the channel has been cancelled or terminated or if an overflow strategy of
@@ -73,7 +74,7 @@ public interface Emitter<T> {
     <M extends Message<? extends T>> void send(M msg);
 
     /**
-     * Sends the completion event to the channel indicating that no other events will be sent afterward. 
+     * Sends the completion event to the channel indicating that no other events will be sent afterward.
      */
     void complete();
 
@@ -90,7 +91,7 @@ public interface Emitter<T> {
     boolean isCancelled();
 
     /**
-     * @return {@code true} if one or more subscribers request messages from the corresponding channel where the emitter connects to, 
+     * @return {@code true} if one or more subscribers request messages from the corresponding channel where the emitter connects to,
      * return {@code false} otherwise.
      */
     boolean hasRequests();

--- a/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
+++ b/api/src/main/java/org/eclipse/microprofile/reactive/messaging/Message.java
@@ -20,6 +20,7 @@ package org.eclipse.microprofile.reactive.messaging;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -67,6 +68,70 @@ public interface Message<T> {
     }
 
     /**
+     * Create a message with the given payload, ack and nack functions.
+     *
+     * @param payload The payload.
+     * @param ack The ack function, this will be invoked when the returned messages {@link #ack()} method is invoked.
+     * @param nack The negative-ack function, this will be invoked when the returned messages {@link #nack(Throwable)}
+     *        method is invoked.
+     * @param <T> the type of payload
+     * @return A message with the given payload, ack and nack functions.
+     */
+    static <T> Message<T> of(T payload,
+                             Supplier<CompletionStage<Void>> ack, Function<Throwable, CompletionStage<Void>> nack) {
+        return new Message<T>() {
+            @Override
+            public T getPayload() {
+                return payload;
+            }
+
+            @Override
+            public Supplier<CompletionStage<Void>> getAck() {
+                return ack;
+            }
+
+            @Override
+            public Function<Throwable, CompletionStage<Void>> getNack() {
+                return nack;
+            }
+        };
+    }
+
+    /**
+     * Creates a new instance of {@link Message} with the specified payload.
+     * The ack/nack functions are taken from the current {@link Message}.
+     *
+     * @param payload the new payload.
+     * @param <P> the type of the new payload
+     * @return the new instance of {@link Message}
+     */
+    default <P> Message<P> withPayload(P payload) {
+        return Message.of(payload, getAck(), getNack());
+    }
+
+    /**
+     * Creates a new instance of {@link Message} with the given acknowledgement supplier.
+     * The payload, and nack function are taken from the current {@link Message}.
+     *
+     * @param ack the positive-acknowledgement function
+     * @return the new instance of {@link Message}
+     */
+    default Message<T> withAck(Supplier<CompletionStage<Void>> ack) {
+        return Message.of(getPayload(), ack, getNack());
+    }
+
+    /**
+     * Creates a new instance of {@link Message} with the given negative-acknowledgement function.
+     * The payload and acknowledgment are taken from the current {@link Message}.
+     *
+     * @param nack the negative-acknowledgement function
+     * @return the new instance of {@link Message}
+     */
+    default Message<T> withNack(Function<Throwable, CompletionStage<Void>> nack) {
+        return Message.of(getPayload(), getAck(), nack);
+    }
+
+    /**
      * @return The payload for this message.
      */
     T getPayload();
@@ -80,6 +145,43 @@ public interface Message<T> {
     default CompletionStage<Void> ack() {
         return CompletableFuture.completedFuture(null);
     }
+
+    /**
+     * @return the supplier used to retrieve the acknowledgement {@link CompletionStage}.
+     */
+    default Supplier<CompletionStage<Void>> getAck() {
+        return () -> CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * @return the function used to retrieve the negative-acknowledgement asynchronous function.
+     */
+    default Function<Throwable, CompletionStage<Void>> getNack() {
+        return reason -> CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Acknowledge negatively this message.
+     * <code>nack</code> is used to indicate that the processing of a message failed with the reason passed as the
+     * parameter.
+     *
+     * @param reason the reason of the nack, must not be {@code null}
+     * @return a completion stage completed when the message is negative-acknowledgement has completed. If the
+     *         negative acknowledgement fails, the completion stage propagates the failure.
+     */
+    default CompletionStage<Void> nack(Throwable reason) {
+        if (reason == null) {
+            throw new IllegalArgumentException("The reason must not be `null`");
+        }
+        Function<Throwable, CompletionStage<Void>> nack = getNack();
+        if (nack == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        else {
+            return nack.apply(reason);
+        }
+    }
+
 
     /**
      * Returns an object of the specified type to allow access to the connector-specific {@link Message} implementation,
@@ -96,7 +198,6 @@ public interface Message<T> {
      * @return an instance of the specified class
      * @throws IllegalArgumentException if the current {@link Message} instance does not support the call
      */
-    @SuppressWarnings({"unchecked"})
     default <C> C unwrap(Class<C> unwrapType) {
         if (unwrapType == null) {
             throw new IllegalArgumentException("The target class must not be `null`");

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <autorelease>false</autorelease>
         <!-- keeping closed repos with failure - default is false because the errors are visible in the maven output, but true will leave the repo open for investigation in Sonatype Nexus -->
         <keepStagingReposOnFailure>false</keepStagingReposOnFailure>
-        <microprofile-config-api.version>1.3</microprofile-config-api.version>
-        <microprofile-metrics-api.version>2.0</microprofile-metrics-api.version>
+        <microprofile-config-api.version>2.0</microprofile-config-api.version>
+        <microprofile-metrics-api.version>3.0</microprofile-metrics-api.version>
         <cdi-api.version>2.0</cdi-api.version>
 
         <revremark>Draft</revremark>

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -73,12 +73,27 @@ For instance, a `KafkaMessage` would provide access to the _topic_ and _partitio
 
 The `org.eclipse.microprofile.reactive.messaging.Message#getPayload` method retrieves the wrapped payload.
 The `org.eclipse.microprofile.reactive.messaging.Message#ack` method acknowledges the message.
-Note that the `ack` method is asynchronous as acknowledgement is generally an asynchronous process.
+The `org.eclipse.microprofile.reactive.messaging.Message#nack` method reports a negative acknowledgement.
+Note that the `ack` and `nack` methods are asynchronous as acknowledgement is generally an asynchronous process.
 
 _Plain_ messages are created using:
 
 * `org.eclipse.microprofile.reactive.messaging.Message#of(T)` - wraps the given payload, no acknowledgement
 * `org.eclipse.microprofile.reactive.messaging.Message#of(T, java.util.function.Supplier<java.util.concurrent.CompletionStage<java.lang.Void>>)` - wraps the given payload and provides the acknowledgment logic
+* `org.eclipse.microprofile.reactive.messaging.Message#of(Supplier<CompletionStage<Void>> ack, Function<Throwable, CompletionStage<Void>> nack)` - wraps the given payload and provides the acknowledgment and negative acknowledgment logic
+
+
+You can also create new `Message` instances by copying the content from an original message using the `withX` methods:
+
+[source, java]
+----
+// Create a new message with a new payload, but using the ack and nack functions from `message`
+Message<T> newMessage = message.withPayload(newPayload);
+// Create a new message with a new ack and nack logic, but using the original payload
+Message<T> another = message
+    .withNack(...)
+    .withAck(...);
+----
 
 ==== Message consumption with @Incoming
 
@@ -149,11 +164,12 @@ A method can combine the `@Incoming` and `@Outgoing` annotation and will then ac
 @Incoming("my-incoming-channel")                            // <1>
 @Outgoing("my-outgoing-channel")                            // <2>
 public Message<String> process(Message<String> message) {
-  return Message.of(message.getPayload().toUpperCase());
+  return message.withPayload(message.getPayload().toUpperCase());  // <3>
 }
 ----
 1. The incoming channel
 2. The outgoing channel
+3. Use the `withPayload` method to preserve the `ack` and `nack` functions
 
 Having the same channel appear in the `@Outgoing` and `@Incoming` annotations of a processor is not supported and will result in an error during deployment.
 
@@ -663,11 +679,18 @@ public PublisherBuilder<Message<I>, Message<O>> process() {
 
 NOTE: Implementations must support implementations of the `Message` interface.
 
-=== Message acknowledgement
+=== Message acknowledgement and negative acknowledgement
 
 Acknowledgement is an important part of message processing.
-Messages are either acknowledged explicitly, or implicitly by the implementation.
-All messages must be acknowledged.
+Acknowlegement indicates that a message has been processed correctly.
+A negative-acknoledgement indicates that a message was not processed correctly.
+
+Messages are either acknowledged (positively or negatively) explicitly, or implicitly by the implementation.
+
+All messages must be acknowledged either positively or negatively.
+What happens when a message is acknowledged depends on the source of the message, often on the connector.
+
+=== Positive acknowledgement
 
 Acknowledgement for the `@Incoming` messages is controlled by the `org.eclipse.microprofile.reactive.messaging.Acknowledgment` annotation.
 The annotation allows configuring the acknowledgement strategy among:
@@ -1062,6 +1085,85 @@ public Message<O> process(Message<I> msg) {
 The implementation is responsible for enforcing the acknowledgement strategy defined by the user when the `@Acknowledgement` policy is used.
 If the annotation is not used, the default policy must be enforced.
 
+=== Negative acknowledgement
+
+Negative acknowledgement indicates a processing failure.
+As for the `POST_PROCESSING` positive acknowledgement strategy, a _nack_ is propagated from a message to its source if the messages are chained.
+When the _nack_ reaches the top of the chain, the source, generally a connector, can handle the failure and act accordingly.
+Typically, sending the invalid message to a dead-letter-queue or retrying the delivery are common strategies.
+
+Negative acknowledgement happens automatically if a method annotated with `@Incoming` receives a single payload and uses `POST_PROCESSING` acknowledgement and throws an exception.
+The incoming message is _nacked_ and the thrown exception is passed as reason.
+The following method would automatically trigger a `nack` if the incoming payload is `b`:
+
+[source, java]
+----
+@Incoming("data")
+@Outgoing("out")
+public String process(String s) {  // <1>
+    if (s.equalsIgnoreCase("b")) {
+        throw new IllegalArgumentException("b"); // <2>
+    }
+    return s.toUpperCase();
+}
+----
+1. `POST_PROCESSING` is the default strategy for this signature
+2. throwing an exception _nacks_ the incoming message
+
+If a method handles payload asynchronously (returns a `CompletionStage`), the incoming message is nacked if:
+
+* the method throws an exception
+* the produced `CompletionStage` is completed exceptionally
+
+[source, java]
+----
+@Incoming("data")
+@Outgoing("out")
+public CompletionStage<String> process(String s) {   // <1>
+    if (s.equalsIgnoreCase("b")) {
+        throw new IllegalArgumentException("b");     // <2>
+    }
+
+    if (s.equalsIgnoreCase("f")) {
+        return null;                                // <3>
+    }
+
+    if (s.equalsIgnoreCase("c")) {
+        CompletableFuture<String> cf = new CompletableFuture<>();
+        cf.completeExceptionally(new IllegalArgumentException("c"));  // <4>
+        return cf;
+    }
+    return CompletableFuture.completedFuture(s.toUpperCase());
+}
+----
+1. `POST_PROCESSING` is the default strategy for this signature
+2. throwing an exception _nacks_ the incoming message
+3. returning `null` nacks the incoming message, as it's illegal to return `null` as `CompletionStage`
+4. returning a `CompletionStage` failed exceptionally also nacks the incoming message
+
+If the method receives a single `Message`, the user is responsible for calling the `nack` function:
+
+[source, java]
+----
+@Incoming("data")
+@Outgoing("out")
+public Message<String> process(Message<String> m) {  // <1>
+    String s = m.getPayload();
+    if (s.equalsIgnoreCase("b")) {
+        // we cannot fail, we must nack explicitly.
+        m.nack(new IllegalArgumentException("b"));  // <2>
+        return null;
+    }
+    return m.withPayload(s.toUpperCase());
+}
+----
+1. `MANUAL` is the default strategy for this signature
+2. throwing an exception would not _nack_ the message, as it may have already been explicitly _acked_ or _nacked_.
+Before the exception happens, the user must call the `nack` method.
+
+Methods using the `NONE` acknowledgement strategy do not _nack_ the incoming message.
+Methods using the `PRE_PROCESSING` acknowledgement strategy, the incoming message is not _nacked_ either, as it was already acknowledged.
+
 === Connector
 
 Reactive Messaging connects matching `@Incoming` and `@Outgoing` stream elements running inside the same application.
@@ -1195,10 +1297,12 @@ The configuration passed to the `IncomingConnectorFactory` and `OutgoingConnecto
 
 ==== Acknowledgement
 
-The connector is responsible for the acknowledgment of the incoming and outgoing messages:
+The connector is responsible for the acknowledgment (positive or negative) of the incoming and outgoing messages:
 
 * An incoming connector must only acknowledge the received message when the produced `org.eclipse.microprofile.reactive.messaging.Message` is acknowledged.
+* An incoming connector must handle received negative acknowledgment.
 * An outgoing connector must acknowledge the incoming `org.eclipse.microprofile.reactive.messaging.Message` once it has successfully dispatched the message.
+* An outgoing connector must acknowledge negatively the incoming `org.eclipse.microprofile.reactive.messaging.Message` if it cannot be dispatched.
 
 == Metrics
 
@@ -1268,8 +1372,12 @@ For a payload type `X`, the following types can be injected:
 
 == Publishing messages to a channel from imperative code
 
-Traditionally, the reactive world and imperative world are separated and operate in parallel. Reactive Messaging deals with streams of data in the reactive world, while the imperative world is pretty much point to point and synchronous communication. However, imperative programme sometimes needs to connect to reactive streams so that responses can be emitted to a destination service.
-Bridging the two worlds is very valuable thing to do, so that one microservice can use technologies from both environments. For an instance, a JAX-RS resource might want to publish messages to a Reactive Messaging channel. This section is about enabling imperative code to publish messages to a Reactive Messaging channel, so that it can be consumed by a consumer.
+Traditionally, the reactive world and imperative world are separated and operate in parallel.
+Reactive Messaging deals with streams of data in the reactive world, while the imperative world is pretty much point to point and synchronous communication.
+However, imperative programme sometimes needs to connect to reactive streams so that responses can be emitted to a destination service.
+Bridging the two worlds is very valuable thing to do, so that one microservice can use technologies from both environments.
+For an instance, a JAX-RS resource might want to publish messages to a Reactive Messaging channel.
+This section is about enabling imperative code to publish messages to a Reactive Messaging channel, so that it can be consumed by a consumer.
 
 You can inject an `Emitter` and use it to send either payloads (`X`) or messages (`Message<X>`) to a channel as demonstrated below.
 
@@ -1285,6 +1393,10 @@ public void publishMessage() {
 }
 ----
 
+When sending payload, the `send` method returns a `CompletionStage`.
+This `CompletionStage` is completed when the emitted message is acknowledged.
+If the processing of the emitter message fails, the returned `CompletionStage` is completed exceptionally.
+
 [source, java]
 ----
 @Inject
@@ -1299,7 +1411,11 @@ public void run() {
 
 ----
 
-When injecting an `Emitter` (e.g. `@Inject Emitter`), you must specify the target channel name using the `@Channel` qualifier. You can then configure how the back pressure is handled via `@OnOverflow` annotation, for the situation where emitting messages/payloads faster than the consumption of the messages.
+When sending a `Message`, the `send` message does not return `CompletionStage`.
+However, you can create a `Message` configured with custom `ack` and `nack` functions.
+
+When injecting an `Emitter` (e.g. `@Inject Emitter<T>`), you must specify the target channel name using the `@Channel` qualifier.
+You can then configure how the back pressure is handled via `@OnOverflow` annotation, for the situation where emitting messages/payloads faster than the consumption of the messages.
 
 [source, java]
 ----

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageProcessorAckTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class AsynchronousMessageProcessorAckTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private MessageProcessor processor;
+
+    @Inject
+    private Sink sink;
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        processor.disableFailureMode();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        assertThat(run(acked, nacked, emitter)).isEmpty();
+
+        await().until(() -> sink.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreNackedAfterFailingProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        processor.enableFailureMode();
+
+        List<Throwable> throwables = run(acked, nacked, emitter);
+
+        await().until(() -> sink.list().size() == 8);
+        assertThat(acked).hasSize(9);
+        assertThat(nacked).hasSize(1);
+        assertThat(throwables).hasSize(1);
+    }
+
+    private List<Throwable> run(Set<String> acked, Set<String> nacked, Emitter<String> emitter)
+        throws InterruptedException, TimeoutException, ExecutionException {
+        List<Throwable> reasons = new CopyOnWriteArrayList<>();
+
+        CompletableFuture.allOf(Stream.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+            .map(i ->
+                CompletableFuture.runAsync(() -> emitter.send(Message.of(i,
+                    () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        reasons.add(t);
+                        nacked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    })))
+                    .thenApply(x -> i)).toArray(CompletableFuture[]::new))
+            .get(10, TimeUnit.SECONDS);
+
+        return reasons;
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+        public void reset() {
+            list.clear();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MessageProcessor {
+
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        @Incoming("data")
+        @Outgoing("out")
+        public CompletionStage<Message<String>> process(Message<String> m) {
+            String s = m.getPayload();
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    return m.nack(new IllegalArgumentException("b")).thenApply(x -> null);
+                }
+
+                if (s.equalsIgnoreCase("e")) {
+                    // acked but not forwarded
+                    return m.ack().thenApply(x -> null);
+                }
+            }
+            return CompletableFuture.supplyAsync(() -> m.withPayload(s.toUpperCase()));
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageSubscriberAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageSubscriberAckTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class AsynchronousMessageSubscriberAckTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, MessageConsumer.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private MessageConsumer processor;
+
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        processor.disableFailureMode();
+        processor.reset();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        assertThat(run(acked, nacked, emitter)).isEmpty();
+
+        await().until(() -> processor.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreNackedAfterFailingProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        processor.enableFailureMode();
+        processor.reset();
+
+        List<Throwable> throwables = run(acked, nacked, emitter);
+
+        await().until(() -> processor.list().size() == 8);
+        assertThat(acked).hasSize(8);
+        assertThat(nacked).hasSize(2);
+        assertThat(throwables).hasSize(2);
+    }
+
+    private List<Throwable> run(Set<String> acked, Set<String> nacked, Emitter<String> emitter)
+        throws InterruptedException, TimeoutException, ExecutionException {
+        List<Throwable> reasons = new CopyOnWriteArrayList<>();
+        CompletableFuture.allOf(Stream.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+            .map(i ->
+                CompletableFuture.runAsync(() -> emitter.send(Message.of(i,
+                    () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        reasons.add(t);
+                        nacked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    })))
+                    .thenApply(x -> i)).toArray(CompletableFuture[]::new))
+            .get(10, TimeUnit.SECONDS);
+
+        return reasons;
+    }
+
+    @ApplicationScoped
+    public static class MessageConsumer {
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        @Acknowledgment(Acknowledgment.Strategy.POST_PROCESSING)
+        public CompletionStage<Void> consume(Message<String> m) {
+            String s = m.getPayload();
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    CompletableFuture<Void> future = new CompletableFuture<>();
+                    future.completeExceptionally(new IllegalArgumentException("b"));
+                    return future;
+                }
+                else if (s.equalsIgnoreCase("h")) {
+                    throw new IllegalStateException("h");
+                }
+            }
+            list.add(s);
+            return m.ack();
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+        public void reset() {
+            list.clear();
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadProcessorAckTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class AsynchronousPayloadProcessorAckTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private MessageProcessor processor;
+
+    @Inject
+    private Sink sink;
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfPayload() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        processor.disableFailureMode();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        run(acked, nacked, emitter);
+
+        await().until(() -> sink.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreNackedAfterFailingProcessingOfPayload() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        Emitter<String> emitter = bean.getEmitter();
+        processor.enableFailureMode();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        List<Throwable> throwables = run(acked, nacked, emitter);
+
+        await().until(() -> sink.list().size() == 7);
+        assertThat(acked).hasSize(7);
+        assertThat(nacked).hasSize(3);
+        assertThat(throwables).hasSize(3);
+    }
+
+
+    private List<Throwable> run(Set<String> acked, Set<String> nacked, Emitter<String> emitter)
+        throws InterruptedException, TimeoutException, ExecutionException {
+        List<Throwable> reasons = new CopyOnWriteArrayList<>();
+        CompletableFuture.allOf(Stream.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+            .map(i ->
+                CompletableFuture.runAsync(() -> emitter.send(Message.of(i,
+                    () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        reasons.add(t);
+                        nacked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    })))
+                    .thenApply(x -> i)).toArray(CompletableFuture[]::new))
+            .get(10, TimeUnit.SECONDS);
+
+        return reasons;
+    }
+
+
+    @ApplicationScoped
+    public static class Sink {
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+        public void reset() {
+            list.clear();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MessageProcessor {
+
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        @Incoming("data")
+        @Outgoing("out")
+        public CompletionStage<String> process(String s) {
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    // nacked
+                    throw new IllegalArgumentException("b");
+                }
+
+                if (s.equalsIgnoreCase("f")) {
+                    // nacked - must not return `null`
+                    return null;
+                }
+
+                if (s.equalsIgnoreCase("c")) {
+                    CompletableFuture<String> cf = new CompletableFuture<>();
+                    cf.completeExceptionally(new IllegalArgumentException("c"));
+                    return cf;
+                }
+            }
+            return CompletableFuture.completedFuture(s.toUpperCase());
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadSubscriberAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadSubscriberAckTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class AsynchronousPayloadSubscriberAckTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, PayloadConsumer.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private PayloadConsumer processor;
+
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        processor.disableFailureMode();
+        processor.reset();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        assertThat(run(acked, nacked, emitter)).isEmpty();
+
+        await().until(() -> processor.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreNackedAfterFailingProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        processor.enableFailureMode();
+        processor.reset();
+
+        List<Throwable> throwables = run(acked, nacked, emitter);
+
+        await().until(() -> processor.list().size() == 8);
+        assertThat(acked).hasSize(8);
+        assertThat(nacked).hasSize(2);
+        assertThat(throwables).hasSize(2);
+    }
+
+    private List<Throwable> run(Set<String> acked, Set<String> nacked, Emitter<String> emitter)
+        throws InterruptedException, TimeoutException, ExecutionException {
+        List<Throwable> reasons = new CopyOnWriteArrayList<>();
+        CompletableFuture.allOf(Stream.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+            .map(i ->
+                CompletableFuture.runAsync(() -> emitter.send(Message.of(i,
+                    () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        reasons.add(t);
+                        nacked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    })))
+                    .thenApply(x -> i)).toArray(CompletableFuture[]::new))
+            .get(10, TimeUnit.SECONDS);
+
+        return reasons;
+    }
+
+    @ApplicationScoped
+    public static class PayloadConsumer {
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public CompletionStage<Void> consume(String s) {
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    CompletableFuture<Void> future = new CompletableFuture<>();
+                    future.completeExceptionally(new IllegalArgumentException("b"));
+                    return future;
+                }
+                else if (s.equalsIgnoreCase("h")) {
+                    throw new IllegalStateException("h");
+                }
+            }
+            list.add(s);
+            return CompletableFuture.completedFuture(null);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+        public void reset() {
+            list.clear();
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterBean.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class EmitterBean {
+    @Inject
+    @Channel("data")
+    private Emitter<String> emitter;
+
+    public Emitter<String> getEmitter() {
+        return emitter;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfMessageAcknowledgementTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfMessageAcknowledgementTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.ServiceLoader;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class EmitterOfMessageAcknowledgementTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, MessageConsumer.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private MessageConsumer processor;
+
+    @Test
+    public void testThatEmitterReceiveAcksAfterSuccessfulProcessingOfPayload() {
+        processor.disableFailureMode();
+        Emitter<String> emitter = bean.getEmitter();
+
+        CompletionStage<Void> completed = CompletableFuture.completedFuture(null);
+
+        AtomicInteger acks = new AtomicInteger();
+        AtomicInteger nacks = new AtomicInteger();
+        emitter.send(Message.of("a", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("b", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("c", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("d", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("e", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+
+        await().until(() -> acks.get() == 5);
+        assertThat(nacks).hasValue(0);
+    }
+
+    @Test
+    public void testThatEmitterReceiveNacksAfterFailingProcessingOfPayload() {
+        Emitter<String> emitter = bean.getEmitter();
+        processor.enableFailureMode();
+
+        CompletionStage<Void> completed = CompletableFuture.completedFuture(null);
+
+        AtomicInteger acks = new AtomicInteger();
+        AtomicInteger nacks = new AtomicInteger();
+        emitter.send(Message.of("a", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("b", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("c", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("d", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+        emitter.send(Message.of("e", () -> {
+            acks.incrementAndGet();
+            return completed;
+        }, r -> {
+            nacks.incrementAndGet();
+            return completed;
+        }));
+
+        await().until(() -> acks.get() == 3);
+        await().until(() -> nacks.get() == 2);
+    }
+
+
+    @ApplicationScoped
+    public static class MessageConsumer {
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        @Incoming("data")
+        public CompletionStage<Void> process(String s) {
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    // nacked
+                    throw new IllegalArgumentException("b");
+                }
+
+                if (s.equalsIgnoreCase("c")) {
+                    CompletableFuture<Void> cf = new CompletableFuture<>();
+                    cf.completeExceptionally(new IllegalArgumentException("c"));
+                    return cf;
+                }
+            }
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfPayloadAcknowledgementTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfPayloadAcknowledgementTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.ServiceLoader;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+public class EmitterOfPayloadAcknowledgementTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, MessageConsumer.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private MessageConsumer processor;
+
+    @Test
+    public void testThatEmitterReceiveAcksAfterSuccessfulProcessingOfPayload() {
+        processor.disableFailureMode();
+        Emitter<String> emitter = bean.getEmitter();
+
+        CompletableFuture<Void> all = CompletableFuture.allOf(
+            emitter.send("a").toCompletableFuture(),
+            emitter.send("b").toCompletableFuture(),
+            emitter.send("c").toCompletableFuture(),
+            emitter.send("d").toCompletableFuture(),
+            emitter.send("e").toCompletableFuture()
+        );
+
+        await().until(all::isDone);
+        assertThat(all.isCompletedExceptionally()).isFalse();
+        assertThat(all.isCancelled()).isFalse();
+    }
+
+    @Test
+    public void testThatEmitterReceiveNacksAfterFailingProcessingOfPayload() {
+        Emitter<String> emitter = bean.getEmitter();
+        processor.enableFailureMode();
+
+        emitter.send("a").toCompletableFuture().join();
+        assertThatThrownBy(() ->
+            emitter.send("b").toCompletableFuture().join()
+        ).hasRootCauseInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() ->
+            emitter.send("c").toCompletableFuture().join()
+        ).hasRootCauseInstanceOf(IllegalArgumentException.class);
+        emitter.send("d").toCompletableFuture().join();
+    }
+
+
+    @ApplicationScoped
+    public static class MessageConsumer {
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        @Incoming("data")
+        public CompletionStage<Void> process(String s) {
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    // nacked
+                    throw new IllegalArgumentException("b");
+                }
+
+                if (s.equalsIgnoreCase("c")) {
+                    CompletableFuture<Void> cf = new CompletableFuture<>();
+                    cf.completeExceptionally(new IllegalArgumentException("c"));
+                    return cf;
+                }
+            }
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/MessageProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/MessageProcessorAckTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class MessageProcessorAckTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private MessageProcessor processor;
+
+    @Inject
+    private Sink sink;
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        processor.disableFailureMode();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        assertThat(run(acked, nacked, emitter)).isEmpty();
+
+        await().until(() -> sink.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreNackedAfterFailingProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        processor.enableFailureMode();
+
+        List<Throwable> throwables = run(acked, nacked, emitter);
+
+        await().until(() -> sink.list().size() == 9);
+        assertThat(acked).hasSize(9);
+        assertThat(nacked).hasSize(1);
+        assertThat(throwables).hasSize(1);
+    }
+
+    private List<Throwable> run(Set<String> acked, Set<String> nacked, Emitter<String> emitter)
+        throws InterruptedException, TimeoutException, ExecutionException {
+        List<Throwable> reasons = new CopyOnWriteArrayList<>();
+        CompletableFuture.allOf(Stream.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+            .map(i ->
+                CompletableFuture.runAsync(() -> emitter.send(Message.of(i,
+                    () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        reasons.add(t);
+                        nacked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    })))
+                    .thenApply(x -> i)).toArray(CompletableFuture[]::new))
+            .get(10, TimeUnit.SECONDS);
+
+        return reasons;
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+        public void reset() {
+            list.clear();
+        }
+    }
+
+    @ApplicationScoped
+    public static class MessageProcessor {
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        @Incoming("data")
+        @Outgoing("out")
+        public Message<String> process(Message<String> m) {
+            String s = m.getPayload();
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    // we cannot fail, we must nack explicitly.
+                    m.nack(new IllegalArgumentException("b")).toCompletableFuture().join();
+                    return null;
+                }
+            }
+            return m.withPayload(s.toUpperCase());
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadProcessorAckTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class PayloadProcessorAckTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, Sink.class, PayloadProcessor.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private PayloadProcessor processor;
+
+    @Inject
+    private Sink sink;
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        processor.disableFailureMode();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        assertThat(run(acked, nacked, emitter)).isEmpty();
+
+        await().until(() -> sink.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreNackedAfterFailingProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        sink.reset();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        processor.enableFailureMode();
+
+        List<Throwable> throwables = run(acked, nacked, emitter);
+
+        await().until(() -> sink.list().size() == 9);
+        assertThat(acked).hasSize(9);
+        assertThat(nacked).hasSize(1);
+        assertThat(throwables).hasSize(1);
+    }
+
+    private List<Throwable> run(Set<String> acked, Set<String> nacked, Emitter<String> emitter)
+        throws InterruptedException, TimeoutException, ExecutionException {
+        List<Throwable> reasons = new CopyOnWriteArrayList<>();
+        CompletableFuture.allOf(Stream.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+            .map(i ->
+                CompletableFuture.runAsync(() -> emitter.send(Message.of(i,
+                    () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        reasons.add(t);
+                        nacked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    })))
+                    .thenApply(x -> i)).toArray(CompletableFuture[]::new))
+            .get(10, TimeUnit.SECONDS);
+
+        return reasons;
+    }
+
+    @ApplicationScoped
+    public static class Sink {
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("out")
+        public void consume(String s) {
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+        public void reset() {
+            list.clear();
+        }
+    }
+
+    @ApplicationScoped
+    public static class PayloadProcessor {
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        @Incoming("data")
+        @Outgoing("out")
+        public String process(String s) {
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b")) {
+                    throw new IllegalArgumentException("b");
+                }
+            }
+            return s.toUpperCase();
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadSubscriberAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadSubscriberAckTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
+
+import org.eclipse.microprofile.reactive.messaging.Emitter;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
+import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class PayloadSubscriberAckTest extends TckBase {
+
+    @Deployment
+    public static Archive<JavaArchive> deployment() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EmitterBean.class, PayloadConsumer.class, ArchiveExtender.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
+        return archive;
+    }
+
+    @Inject
+    private EmitterBean bean;
+
+    @Inject
+    private PayloadConsumer processor;
+
+    @Test
+    public void testThatMessagesAreAckedAfterSuccessfulProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        processor.reset();
+        processor.disableFailureMode();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        assertThat(run(acked, nacked, emitter)).isEmpty();
+
+        await().until(() -> processor.list().size() == 10);
+        assertThat(acked).hasSize(10);
+        assertThat(nacked).hasSize(0);
+    }
+
+    @Test
+    public void testThatMessagesAreNackedAfterFailingProcessingOfMessage() throws InterruptedException, TimeoutException, ExecutionException {
+        processor.reset();
+        Emitter<String> emitter = bean.getEmitter();
+
+        Set<String> acked = ConcurrentHashMap.newKeySet();
+        Set<String> nacked = ConcurrentHashMap.newKeySet();
+
+        processor.enableFailureMode();
+
+        List<Throwable> throwables = run(acked, nacked, emitter);
+
+        await().until(() -> processor.list().size() == 8);
+        assertThat(acked).hasSize(8);
+        assertThat(nacked).hasSize(2);
+        assertThat(throwables).hasSize(2);
+    }
+
+    private List<Throwable> run(Set<String> acked, Set<String> nacked, Emitter<String> emitter)
+        throws InterruptedException, TimeoutException, ExecutionException {
+        List<Throwable> reasons = new CopyOnWriteArrayList<>();
+        CompletableFuture.allOf(Stream.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+            .map(i ->
+                CompletableFuture.runAsync(() -> emitter.send(Message.of(i,
+                    () -> {
+                        acked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    }, t -> {
+                        reasons.add(t);
+                        nacked.add(i);
+                        return CompletableFuture.completedFuture(null);
+                    })))
+                    .thenApply(x -> i)).toArray(CompletableFuture[]::new))
+            .get(10, TimeUnit.SECONDS);
+
+        return reasons;
+    }
+
+    @ApplicationScoped
+    public static class PayloadConsumer {
+
+        private boolean failureModeEnabled = false;
+
+        public void enableFailureMode() {
+            failureModeEnabled = true;
+        }
+
+        public void disableFailureMode() {
+            failureModeEnabled = false;
+        }
+
+        private final List<String> list = new CopyOnWriteArrayList<>();
+
+        @Incoming("data")
+        public void consume(String s) {
+            if (failureModeEnabled) {
+                if (s.equalsIgnoreCase("b") || s.equalsIgnoreCase("h")) {
+                    throw new IllegalArgumentException("boom");
+                }
+            }
+            list.add(s);
+        }
+
+        public List<String> list() {
+            return list;
+        }
+
+        public void reset() {
+            list.clear();
+        }
+    }
+
+}


### PR DESCRIPTION
Add support for negative acknowledgement

* Add `nack` method to the `Message` interface
* Explain `ack` / `nack` on the `Emitter` javadoc
* Extend specification to cover negative acknowledgement
* Extend TCK to verify acknowledgement and negative-acknowledgement

