### PR TITLE
Make sure TCKs are CDI-version agnostic

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/channel/BeanWithMissingChannel.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/channel/BeanWithMissingChannel.java
@@ -21,8 +21,10 @@ package org.eclipse.microprofile.reactive.messaging.tck.channel;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class BeanWithMissingChannel {
     @Inject
     @Channel("missing")

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithBadOutgoingSignature.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithBadOutgoingSignature.java
@@ -20,6 +20,9 @@ package org.eclipse.microprofile.reactive.messaging.tck.invalid;
 
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class BeanWithBadOutgoingSignature {
 
     @Outgoing("foo")

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyIncoming.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyIncoming.java
@@ -20,6 +20,9 @@ package org.eclipse.microprofile.reactive.messaging.tck.invalid;
 
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class BeanWithEmptyIncoming {
 
     @Incoming("")

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyOutgoing.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithEmptyOutgoing.java
@@ -20,6 +20,9 @@ package org.eclipse.microprofile.reactive.messaging.tck.invalid;
 
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class BeanWithEmptyOutgoing {
 
     @Outgoing("")

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithIncompleteChain.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/invalid/BeanWithIncompleteChain.java
@@ -21,6 +21,9 @@ package org.eclipse.microprofile.reactive.messaging.tck.invalid;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class BeanWithIncompleteChain {
 
     @Incoming("missing")


### PR DESCRIPTION
Fixes #151 

These were the only tests that started failing for me once I tried with CDI 4. The rest works just fine as-is, so I didn't touch it.

To reiterate myself - this doesn't change the TCK behavior in any way. It simply makes it CDI-version agnostic so that the TCK works with CDI 3 and CDI 4 implementations. It will ease transition for any early adopters and will eliminate future fraction when actual migration to EE 10 happens. See linked issue for more information.

This change was tested with SR impl customized to run the TCKs on Weld 5 container and the tests passed.