### PR TITLE
Remove reference to lightbend implementation from Readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,7 +29,6 @@ MicroProfile Reactive Messaging does not contain an implementation itself but on
 
 The following implementations are available:
 
-* https://github.com/lightbend/microprofile-reactive-messaging[Lightbend Alpakka]
 * https://www.smallrye.io/smallrye-reactive-messaging[SmallRye Reactive Messaging]
 * https://openliberty.io/downloads/#runtime_releases[Open Liberty 19.0.0.9+] https://openliberty.io/blog/2019/09/13/microprofile-reactive-messaging-19009.html#mpreactive[usage] (via SmallRye Reactive Messaging)
 


### PR DESCRIPTION
Removing reference to https://github.com/lightbend/microprofile-reactive-messaging as it has been archived and is no longer developed.