### PR TITLE
Include TckBase.class in application archives where test class extends TckBase

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageProcessorAckTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -37,12 +36,9 @@ import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -53,12 +49,8 @@ public class AsynchronousMessageProcessorAckTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageSubscriberAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousMessageSubscriberAckTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -37,12 +36,9 @@ import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -53,12 +49,8 @@ public class AsynchronousMessageSubscriberAckTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, MessageConsumer.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, MessageConsumer.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadProcessorAckTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -37,12 +36,9 @@ import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -53,12 +49,8 @@ public class AsynchronousPayloadProcessorAckTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadSubscriberAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/AsynchronousPayloadSubscriberAckTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -36,12 +35,9 @@ import java.util.stream.Stream;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -52,12 +48,8 @@ public class AsynchronousPayloadSubscriberAckTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, PayloadConsumer.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, PayloadConsumer.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfMessageAcknowledgementTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfMessageAcknowledgementTest.java
@@ -21,7 +21,6 @@ package org.eclipse.microprofile.reactive.messaging.tck.acknowledgement;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -29,12 +28,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -45,12 +41,8 @@ public class EmitterOfMessageAcknowledgementTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, MessageConsumer.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, MessageConsumer.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfPayloadAcknowledgementTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/EmitterOfPayloadAcknowledgementTest.java
@@ -22,18 +22,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
-import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -44,12 +40,8 @@ public class EmitterOfPayloadAcknowledgementTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, MessageConsumer.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, MessageConsumer.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/MessageProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/MessageProcessorAckTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,12 +35,9 @@ import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -52,12 +48,8 @@ public class MessageProcessorAckTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, Sink.class, MessageProcessor.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadProcessorAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadProcessorAckTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,12 +35,9 @@ import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -52,12 +48,8 @@ public class PayloadProcessorAckTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, Sink.class, PayloadProcessor.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, Sink.class, PayloadProcessor.class);
     }
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadSubscriberAckTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/reactive/messaging/tck/acknowledgement/PayloadSubscriberAckTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,12 +34,9 @@ import java.util.stream.Stream;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
-import org.eclipse.microprofile.reactive.messaging.tck.ArchiveExtender;
 import org.eclipse.microprofile.reactive.messaging.tck.TckBase;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 
@@ -51,12 +47,8 @@ public class PayloadSubscriberAckTest extends TckBase {
 
     @Deployment
     public static Archive<JavaArchive> deployment() {
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
-                .addClasses(EmitterBean.class, PayloadConsumer.class, ArchiveExtender.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-
-        ServiceLoader.load(ArchiveExtender.class).iterator().forEachRemaining(ext -> ext.extend(archive));
-        return archive;
+        return getBaseArchive()
+                .addClasses(EmitterBean.class, PayloadConsumer.class);
     }
 
     @Inject


### PR DESCRIPTION
During running of the 3.0 TCK. It was found that for a number of the newer test classes that extended TckBase, did not include the TckBase class in the application archive would throw ClassNotFoundException TckBase when run on Open Liberty.

Use the `getBaseArchive()` to include base classes and configuration and only add the additional classes for those tests.

All the affected tests use the same ServiceLoader and manifest resource as defined in `getBaseArchive()`