### PR TITLE
Update to MicroProfile Parent 2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
     name: build with jdk ${{matrix.java}}
 
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.5</version>
+        <version>2.8</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.reactive.messaging</groupId>
@@ -41,6 +41,7 @@
         <version.microprofile.metrics>4.0</version.microprofile.metrics>
         <version.microprofile.reactive.streams.operators>3.0</version.microprofile.reactive.streams.operators>
         <version.osgi.versioning>1.1.0</version.osgi.versioning>
+        <version.microprofile.tck.bom>2.8</version.microprofile.tck.bom>
 
         <!-- Test -->
         <version.awaitability>4.1.0</version.awaitability>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -30,6 +30,18 @@
 
     <artifactId>microprofile-reactive-messaging-tck</artifactId>
     <name>MicroProfile Reactive Messaging - TCK</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.microprofile</groupId>
+                <artifactId>microprofile-tck-bom</artifactId>
+                <version>${version.microprofile.tck.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Brings in the latest versions of our build and test dependencies.

Required to build on the latest version of Maven